### PR TITLE
Added Q-expressions

### DIFF
--- a/src/Mindy/Orm/Q/AndQ.php
+++ b/src/Mindy/Orm/Q/AndQ.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *
+ *
+ * All rights reserved.
+ *
+ * @author Okulov Anton
+ * @email qantus@mail.ru
+ * @version 1.0
+ * @company Studio107
+ * @site http://studio107.ru
+ * @date 23/06/15 14:48
+ */
+
+namespace Mindy\Orm\Q;
+
+
+class AndQ extends Q
+{
+    public function getQueryCondition()
+    {
+        return ['and'];
+    }
+
+    public function getQueryJoinCondition()
+    {
+        return ['and'];
+    }
+}

--- a/src/Mindy/Orm/Q/OrQ.php
+++ b/src/Mindy/Orm/Q/OrQ.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *
+ *
+ * All rights reserved.
+ *
+ * @author Okulov Anton
+ * @email qantus@mail.ru
+ * @version 1.0
+ * @company Studio107
+ * @site http://studio107.ru
+ * @date 23/06/15 14:48
+ */
+
+namespace Mindy\Orm\Q;
+
+
+class OrQ extends Q
+{
+    public function getQueryCondition()
+    {
+        return ['or'];
+    }
+
+    public function getQueryJoinCondition()
+    {
+        return ['and'];
+    }
+}

--- a/src/Mindy/Orm/Q/Q.php
+++ b/src/Mindy/Orm/Q/Q.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *
+ *
+ * All rights reserved.
+ *
+ * @author Okulov Anton
+ * @email qantus@mail.ru
+ * @version 1.0
+ * @company Studio107
+ * @site http://studio107.ru
+ * @date 23/06/15 14:39
+ */
+
+namespace Mindy\Orm\Q;
+
+use Exception;
+use Mindy\Helper\Traits\Accessors;
+
+abstract class Q
+{
+    use Accessors;
+
+    protected $_conditions = [];
+
+    public function __construct(array $conditions = [])
+    {
+        foreach($conditions as $condition) {
+            if (!is_array($condition)) {
+                throw new Exception('Conditions must be arrays');
+            }
+            $this->_conditions[] = $condition;
+        }
+    }
+
+    public function getConditions()
+    {
+        return $this->_conditions;
+    }
+
+    abstract public function getQueryCondition();
+
+    abstract public function getQueryJoinCondition();
+}

--- a/src/Mindy/Orm/QuerySet.php
+++ b/src/Mindy/Orm/QuerySet.php
@@ -5,7 +5,6 @@ namespace Mindy\Orm;
 use Mindy\Exception\Exception;
 use Mindy\Helper\Creator;
 use Mindy\Orm\Exception\MultipleObjectsReturned;
-use Mindy\Orm\Expressions\Expression;
 use Mindy\Orm\Fields\ManyToManyField;
 use Mindy\Orm\Q\Q;
 

--- a/src/Mindy/Orm/QuerySet.php
+++ b/src/Mindy/Orm/QuerySet.php
@@ -7,6 +7,7 @@ use Mindy\Helper\Creator;
 use Mindy\Orm\Exception\MultipleObjectsReturned;
 use Mindy\Orm\Expressions\Expression;
 use Mindy\Orm\Fields\ManyToManyField;
+use Mindy\Orm\Q\Q;
 
 /**
  * Class QuerySet
@@ -632,7 +633,7 @@ class QuerySet extends QuerySetBase
         $resultQuery = [];
         foreach($query as $key => $queryItem)
         {
-            if ($queryItem instanceof Expression) {
+            if ($queryItem instanceof Q) {
                 $queryCondition = $queryItem->getQueryCondition();
                 $expressionQueryJoin = $queryItem->getQueryJoinCondition();
                 $expressionConditionGroups = $queryItem->getConditions();

--- a/src/Mindy/Orm/QuerySet.php
+++ b/src/Mindy/Orm/QuerySet.php
@@ -715,7 +715,7 @@ class QuerySet extends QuerySetBase
             $lookupParams = array_merge($lookupParams, $params);
             $lookupQuery[] = $query;
         }
-        
+
         return [$lookupQuery, $lookupParams];
     }
 

--- a/src/Mindy/Orm/QuerySet.php
+++ b/src/Mindy/Orm/QuerySet.php
@@ -715,6 +715,7 @@ class QuerySet extends QuerySetBase
             $lookupParams = array_merge($lookupParams, $params);
             $lookupQuery[] = $query;
         }
+        
         return [$lookupQuery, $lookupParams];
     }
 


### PR DESCRIPTION
Добавлены Q-выражения для удобства работы с filter / exclude

Пример:

```php
...
$qs->filter([new OrQ([
            ['status__in' => [1,2,3], 'id' => '1'],
            ['id__gt' => 1, 'status' => 1],
            ['id__lte' => 1, 'status' => 5]
])]);
...
```

Построит условие

```sql
...
WHERE 
(
	((`table_1`.`status` IN (1, 2, 3)) AND (`table_1`.`id`='1')) 
	OR (((`table_1`.`id` > 1)) AND (`table_1`.`status`=1)) 
	OR (((`table_1`.`id` <= 1)) AND (`table_1`.`status`=5))
)
...
```