### PR TITLE
Fix unserialize method

### DIFF
--- a/src/Mindy/Orm/Base.php
+++ b/src/Mindy/Orm/Base.php
@@ -1531,6 +1531,8 @@ abstract class Base implements ArrayAccess, Serializable
      */
     public function unserialize($serialized)
     {
-        $this->setDbAttributes(unserialize($serialized));
+        $attributes = unserialize($serialized);
+        $this->setDbAttributes($attributes);
+        $this->setOldAttributes($attributes);
     }
 }


### PR DESCRIPTION
При unserialize получали объект без oldAttributes, вследствие чего объект распознаётся как true в любом случае.